### PR TITLE
Shrink goembed source files

### DIFF
--- a/goembed.go
+++ b/goembed.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"os"
 	"text/template"
+	"unicode/utf8"
 )
 
 var (
@@ -94,11 +95,55 @@ func oneVarReader(varName string, r io.Reader) error {
 		raw = gz
 	}
 
-	for _, b := range raw {
-		fmt.Printf("\\x%02x", b)
-	}
+	io.Copy(&writer{w: os.Stdout}, bytes.NewReader(raw))
 	fmt.Println(`")`)
 	return nil
+}
+
+type writer struct {
+	w io.Writer
+}
+
+func (w *writer) Write(data []byte) (n int, err error) {
+	n = len(data)
+
+	for err == nil && len(data) > 0 {
+		// https://golang.org/ref/spec#String_literals: "Within the quotes, any
+		// character may appear except newline and unescaped double quote. The
+		// text between the quotes forms the value of the literal, with backslash
+		// escapes interpreted as they are in rune literals […]."
+		switch b := data[0]; b {
+		case '\\':
+			_, err = w.w.Write([]byte(`\\`))
+		case '"':
+			_, err = w.w.Write([]byte(`\"`))
+		case '\n':
+			_, err = w.w.Write([]byte(`\n`))
+
+		case '\x00':
+			// https://golang.org/ref/spec#Source_code_representation: "Implementation
+			// restriction: For compatibility with other tools, a compiler may
+			// disallow the NUL character (U+0000) in the source text."
+			_, err = w.w.Write([]byte(`\x00`))
+
+		default:
+			// https://golang.org/ref/spec#Source_code_representation: "Implementation
+			// restriction: […] A byte order mark may be disallowed anywhere else in
+			// the source."
+			const byteOrderMark = '\uFEFF'
+
+			if r, size := utf8.DecodeRune(data); r != utf8.RuneError && r != byteOrderMark {
+				_, err = w.w.Write(data[:size])
+				data = data[size:]
+				continue
+			}
+
+			_, err = fmt.Fprintf(w.w, `\x%02x`, b)
+		}
+		data = data[1:]
+	}
+
+	return n - len(data), err
 }
 
 var gzipPrologue = template.Must(template.New("").Parse(`


### PR DESCRIPTION
…by only escaping string-escape characters and bytes that are not valid
in (UTF-8) Go source code.

Before this commit, an 11M executable resulted in 41M of Go source.
After this commit, the same executable results in 27M of Go source.
For textual input, the effect is more pronounced.